### PR TITLE
Do not call C Runtime functions from thread_proc() or replace_wchar()

### DIFF
--- a/Win10Pin2TB/Win10Pin2TB.cpp
+++ b/Win10Pin2TB/Win10Pin2TB.cpp
@@ -33,7 +33,10 @@ static const void WINAPI replace_wchar(const wchar_t *srcStr, wchar_t replaceCha
 	if (srcStr == NULL)
 		return ;
 
-	int strLen = (int)wcslen(srcStr);
+	int strLen = 0;
+	const wchar_t* sptr = srcStr;
+	while (*sptr++) ++strLen;
+
 	if (strLen >= 0)
 	{
 		int lastIndex = strLen;
@@ -76,11 +79,11 @@ static DWORD WINAPI thread_func(void* pContextData)
 	{
 		HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
 		LoadStringW(hShell32, opCode, commandString, MAX_PATH);
-		_wcslwr_s(commandString);
+		CharLowerW(commandString);
 	}
 	else
 	{
-		wcscpy_s(commandString, (WCHAR*)((char*)pContextData + MAX_PATH * 4));
+		StringCchCopyW(commandString, MAX_PATH, (WCHAR*)((char*)pContextData + MAX_PATH * 4));
 	}
 
 	IShellDispatch* pIShellDispatch = NULL;
@@ -129,13 +132,12 @@ static DWORD WINAPI thread_func(void* pContextData)
 						{
 							BSTR pVerbName = NULL;
 							hResult = pVerb->get_Name(&pVerbName);
-							if (pVerbName == NULL || wcslen((wchar_t*)pVerbName)==0)
+							if (pVerbName == NULL || *(wchar_t*)pVerbName == 0)
 								continue;
-							memset(tempName, 0, MAX_PATH * 2);//in Syspin,directly change pVerName could led memory corrupt Edited by xyq@2019-11-1 15:17:22
-							wcscpy_s(tempName, pVerbName);
+							StringCchCopyW(tempName, MAX_PATH, pVerbName);
 							replace_wchar((wchar_t*)tempName, L'&');
-							_wcslwr_s((wchar_t*)tempName, MAX_PATH);
-							if (SUCCEEDED(hResult) && !wcscmp((wchar_t*)tempName, commandString))
+							CharLowerW(tempName);
+							if (SUCCEEDED(hResult) && !lstrcmpW((wchar_t*)tempName, commandString))
 							{
 								pTargetVerb = pVerb;
 								break;

--- a/Win10Pin2TB/Win10Pin2TB.cpp
+++ b/Win10Pin2TB/Win10Pin2TB.cpp
@@ -212,7 +212,7 @@ BOOL __fastcall InjectFun2Explorer(LPCVOID lpThreadArgs, HANDLE hProcess, thread
 							}
 						}
 					}
-					((char*)pLocalMem)[pNTH->OptionalHeader.AddressOfEntryPoint] = 0x55;//todo:why change entryPoint？Edited by xyq@2019-10-24 16:06:08
+
 					if (WriteProcessMemory(hProcess, pProgman_mem, pLocalMem, image_size, 0i64))
 					{
 						SIZE_T NumberOfBytesWritten = 0;

--- a/Win10Pin2TB/Win10Pin2TB.vcxproj
+++ b/Win10Pin2TB/Win10Pin2TB.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{38809E2C-E79D-4B39-94F1-9BFDB4AF7518}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Win10Pin2TB</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Windows Explorer does not have the C Runtime loaded into its address space.  Calling such functions via a remote thread causes Explorer to crash.

Replaced C Runtime calls with equivalent Win32 system calls.